### PR TITLE
Add docker support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,36 @@
+# See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
+
+# dependencies
+/node_modules
+/.pnp
+.pnp.js
+
+# testing
+/coverage
+
+# next.js
+/.next/
+/out/
+
+# production
+/build
+
+# misc
+.DS_Store
+*.pem
+
+# debug
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# local env files
+.env*.local
+.env
+
+# vercel
+.vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,51 @@
+# Install dependencies only when needed
+FROM node:lts-bullseye-slim AS deps
+# Check https://github.com/nodejs/docker-node/tree/b4117f9333da4138b03a546ec926ef50a31506c3#nodealpine to understand why libc6-compat might be needed.
+RUN apt update 
+WORKDIR /app
+
+COPY package.json package-lock.json ./ 
+RUN npm install
+
+# Rebuild the source code only when needed
+FROM node:lts-bullseye-slim AS builder
+WORKDIR /app
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+
+# Next.js collects completely anonymous telemetry data about general usage.
+# Learn more here: https://nextjs.org/telemetry
+# Uncomment the following line in case you want to disable telemetry during the build.
+# ENV NEXT_TELEMETRY_DISABLED 1
+
+RUN npx prisma generate
+RUN npm run build
+
+# Production image, copy all the files and run next
+FROM node:lts-bullseye-slim AS runner
+WORKDIR /app
+
+ENV NODE_ENV production
+# Uncomment the following line in case you want to disable telemetry during runtime.
+# ENV NEXT_TELEMETRY_DISABLED 1
+
+RUN addgroup --system --gid 1001 nodejs
+RUN adduser --system --uid 1001 nextjs
+
+# You only need to copy next.config.js if you are NOT using the default configuration
+# COPY --from=builder /app/next.config.js ./
+COPY --from=builder /app/public ./public
+COPY --from=builder /app/package.json ./package.json
+
+# Automatically leverage output traces to reduce image size 
+# https://nextjs.org/docs/advanced-features/output-file-tracing
+COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
+COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
+
+USER nextjs
+
+EXPOSE 3000
+
+ENV PORT 3000
+
+CMD ["node", "server.js"]

--- a/README.md
+++ b/README.md
@@ -34,3 +34,30 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/deployment) for more details.
+
+## Self hosting with docker
+
+Although the project is not yet available on Docker Hub, you can self-host it by building the Docker image yourself. Follow these steps to get started:
+
+**Step 1** : install the docker engine ([how to install docker](https://docs.docker.com/engine/install/))
+
+**Step 2** : clone the repository 
+
+**Step 3** : build the container
+
+```bash
+docker build . -t devoolboxweb
+```
+**Step 4** get api key on [Clerk](https://dashboard.clerk.com/sign-in)
+**Step 5** : run the docker with needed variables : 
+
+```bash
+docker container run \
+    --name devoolboxweb \
+    -p 3000:3000 \
+    -e NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=your_key \
+    -e CLERK_SECRET_KEY=your_secret_key \
+    devoolboxweb
+```
+
+Note : without the vars `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` and `CLERK_SECRET_KEY` , the container will throw error code 500.

--- a/next.config.js
+++ b/next.config.js
@@ -1,5 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  output: 'standalone',
   experimental: {
     serverActions: true,
   },


### PR DESCRIPTION
Close YourAverageTechBro/DevToolboxWeb#10

For the dockerFile I reused the [next.js official docker exemple](https://github.com/vercel/next.js/blob/f110a3735b9c4cbdc23b302592f5c24e6a666f02/examples/with-docker/Dockerfile)
But I prefere use lts-bullseye-slim node version instead of 16-alpine tag because it's almost the same weight but much stable in my opinion.

I have also add a readme part about how to use the DockerFile

feel free to comment and critic my work 😇