### PR TITLE
fix: inconsistencies in title formating

### DIFF
--- a/src/app/components/common/FormatedJsonOutput.tsx
+++ b/src/app/components/common/FormatedJsonOutput.tsx
@@ -21,7 +21,7 @@ type Props = {
 };
 export default function FormattedJsonOutput({
   value,
-  title = "output",
+  title = "Output",
 }: Props) {
   const [jsonPathFilter, setJsonPathFilter] = useState("");
   const [numberOfSpaces, setNumberOfSpaces] = useState(2);

--- a/src/app/components/common/ReadOnlyTextArea.tsx
+++ b/src/app/components/common/ReadOnlyTextArea.tsx
@@ -3,7 +3,7 @@ type Props = {
   // eslint-disable-next-line react/require-default-props
   title?: string;
 };
-export default function ReadOnlyTextArea({ value, title = "output:" }: Props) {
+export default function ReadOnlyTextArea({ value, title = "Output:" }: Props) {
   return (
     <div className="w-full h-full">
       <div className="flex items-center mb-4 gap-4 justify-between">

--- a/src/app/tools/base64encoder/Base64EncoderClientComponent.tsx
+++ b/src/app/tools/base64encoder/Base64EncoderClientComponent.tsx
@@ -80,7 +80,7 @@ export default function Bas64EncoderComponent({
     <div className="w-full h-full flex gap-4">
       <div className="w-full h-full">
         <div className="flex items-center mb-4 gap-4">
-          <p className="font-bold text-xl"> input: </p>
+          <p className="font-bold text-xl"> Input: </p>
           <button
             type="button"
             className="rounded-md bg-indigo-500 px-3.5 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-500"

--- a/src/app/tools/character-and-word-counter/CharacterAndWordCounterComponent.tsx
+++ b/src/app/tools/character-and-word-counter/CharacterAndWordCounterComponent.tsx
@@ -82,7 +82,7 @@ export default function CharacterAndWordCounterComponent({
       <div className="w-full h-full">
         <div className="flex justify-between items-center mb-4 gap-4">
           <div className="flex gap-4 items-center">
-            <p className="font-bold text-xl"> input: </p>
+            <p className="font-bold text-xl"> Input: </p>
             <button
               type="button"
               className="rounded-md bg-indigo-500 px-3.5 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-500"
@@ -105,7 +105,7 @@ export default function CharacterAndWordCounterComponent({
 
       <div className="w-full h-full">
         <div className="flex items-center mb-4 gap-4 justify-between">
-          <p className="font-bold text-xl"> output: </p>
+          <p className="font-bold text-xl"> Output: </p>
           <div className="flex gap-4 items-center justify-end w-full">
             <Selector
               values={filterOptions}

--- a/src/app/tools/line-sort-and-dedupe/LineSortAndDedupeComponent.tsx
+++ b/src/app/tools/line-sort-and-dedupe/LineSortAndDedupeComponent.tsx
@@ -137,7 +137,7 @@ export default function LineSortAndDedupeComponent({
     <div className="w-full h-full flex gap-4">
       <div className="w-full h-full">
         <div className="flex items-center mb-4 gap-4">
-          <p className="font-bold text-xl"> input: </p>
+          <p className="font-bold text-xl"> Input: </p>
           <button
             type="button"
             className="rounded-md bg-indigo-500 px-3.5 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-500"

--- a/src/app/tools/regex-checker/RegexCheckerComponent.tsx
+++ b/src/app/tools/regex-checker/RegexCheckerComponent.tsx
@@ -74,7 +74,7 @@ useEffect(() => {
     <div className="w-full h-full flex gap-4">
       <div className="w-full h-full">
         <div className="flex items-center mb-4 gap-4">
-          <p className="font-bold text-xl"> input: </p>
+          <p className="font-bold text-xl"> Input: </p>
           <button
             type="button"
             className="rounded-md bg-indigo-500 px-3.5 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-500"

--- a/src/app/tools/string-converter/StringConverterComponent.tsx
+++ b/src/app/tools/string-converter/StringConverterComponent.tsx
@@ -140,7 +140,7 @@ export default function StringConverterComponent({
       />
       <div className="w-full h-full">
         <div className="flex items-center mb-4 gap-4 justify-between">
-          <p className="font-bold text-xl"> output: </p>
+          <p className="font-bold text-xl"> Output: </p>
           <Selector
             values={options}
             handleClick={(filterOption) => {

--- a/src/app/tools/unix-time-converter/UnixTimeConverterComponent.tsx
+++ b/src/app/tools/unix-time-converter/UnixTimeConverterComponent.tsx
@@ -249,7 +249,7 @@ export default function UnixTimeConverterComponent({
     <div className="w-full h-full flex flex-col gap-4 overflow-y-scroll">
       <div className="w-full">
         <div className="flex gap-4 items-center mb-4">
-          <p className="font-bold text-xl "> input: </p>
+          <p className="font-bold text-xl "> Input: </p>
           <button
             type="button"
             className="rounded-md bg-indigo-500 px-3.5 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-500"
@@ -285,7 +285,7 @@ export default function UnixTimeConverterComponent({
       </div>
       <div className="w-full h-full">
         <div className="flex flex-col mb-4 gap-4">
-          <p className="font-bold text-xl"> output: </p>
+          <p className="font-bold text-xl"> Output: </p>
           <div>
             <p className="font-bold text-sm mb-2">Local Time:</p>
             <div className="flex gap-2">


### PR DESCRIPTION
Simply fixed some inconsitencies in field titles ('input' and 'output'), I capitalized for each first letter that wasn't.