### PR TITLE
Adjust 'select' text overflow in 'Selector' component

### DIFF
--- a/src/app/components/common/Selector.tsx
+++ b/src/app/components/common/Selector.tsx
@@ -21,7 +21,8 @@ export default function Selector<T extends SelectorValue>({
         </p>
       )}
       <select
-        className={`block w-full rounded-md border-0 py-1.5 pl-3 pr-10
+        // Removed 'w-full' and added 'w-fit' to show the overflowing texts of this element.
+        className={`block w-fit rounded-md border-0 py-1.5 pl-3 pr-10
         text-gray-900 ring-1 ring-inset ring-gray-300 focus:ring-2
         focus:ring-indigo-600 sm:text-sm sm:leading-6`}
         onChange={(e) => {


### PR DESCRIPTION
### Problem:
The text inside the _select_ element was overflowing and the excess texts was hidden from the view:

![selector-component-jsonvalidator](https://github.com/YourAverageTechBro/DevToolboxWeb/assets/96349786/54506274-1875-476a-976b-d5064fad805b)

### Solution:
Inside the `Selector` component:
```javascript
...
    <select
        // Removed 'w-full' and added 'w-fit' to show the overflowing texts of this element.
        className={`block w-fit rounded-md border-0 py-1.5 pl-3 pr-10
        text-gray-900 ring-1 ring-inset ring-gray-300 focus:ring-2
        focus:ring-indigo-600 sm:text-sm sm:leading-6`}
...
```

### Final view:

![FIXED-selector-component-jsonvalidator](https://github.com/YourAverageTechBro/DevToolboxWeb/assets/96349786/e39c58f3-10a7-476c-b07d-a9121c6acbc6)



