### PR TITLE
fix: format json after filtering

### DIFF
--- a/src/app/components/common/FormatedJsonOutput.tsx
+++ b/src/app/components/common/FormatedJsonOutput.tsx
@@ -142,7 +142,7 @@ export default function FormattedJsonOutput({
       </div>
 
       <pre
-        className="px-8 py-2 block rounded-lg border-0
+        className="px-4 py-2 block rounded-lg border-0
         bg-gray-700 shadow-sm ring-1 ring-inset
         ring-gray-300 focus:ring-2 focus:ring-inset
         focus:ring-indigo-600 sm:text-sm sm:leading-6 language-json whitespace-pre-wrap

--- a/src/app/components/common/FormatedJsonOutput.tsx
+++ b/src/app/components/common/FormatedJsonOutput.tsx
@@ -82,6 +82,12 @@ export default function FormattedJsonOutput({
     }
   };
 
+  const setFormattedJson = (jsonString: string) => {
+    const formattedJson = formatJson(jsonString);
+    setOutput(formattedJson);
+    setDangerousHtml(syntaxHighlight(formattedJson));
+  };
+
   useEffect(() => {
     try {
       if (debouncedJsonPathFilter) {
@@ -91,17 +97,12 @@ export default function FormattedJsonOutput({
             jsonPathFilter
           )
         );
-        setOutput(filteredJson);
-        setDangerousHtml(syntaxHighlight(filteredJson));
+        setFormattedJson(filteredJson);
       } else {
-        const json = formatJson(value);
-        setOutput(json);
-        setDangerousHtml(syntaxHighlight(json));
+        setFormattedJson(value);
       }
     } catch (e: any) {
-      const json = formatJson(value);
-      setOutput(json);
-      setDangerousHtml(syntaxHighlight(json));
+      setFormattedJson(value);
     }
   }, [
     formatJson,
@@ -150,7 +151,7 @@ export default function FormattedJsonOutput({
         style={{ height: "calc(100% - 96px)" }}
       />
       <input
-        className={`mt-4 block w-full rounded-md border-0 py-1.5
+        className={`mt-4 px-8 block w-full rounded-md border-0 py-1.5
       text-white shadow-sm ring-1 ring-inset ring-gray-300
       placeholder:text-gray-400 focus:ring-2 focus:ring-inset
       focus:ring-indigo-600 sm:text-sm sm:leading-6 bg-gray-600`}


### PR DESCRIPTION
In the JSON Validator, the JSON path filter shows us the filtered JSON value but it is not formatted. This PR:

1. Formats the filtered JSON
2. Adds 4px horizontal padding to the search bar placeholder text