### PR TITLE
BUG FIX:  String Converter Tool  | kebab-case | SCREAM-KEBAB 

### DIFF
--- a/src/app/tools/string-converter/StringConverterComponent.tsx
+++ b/src/app/tools/string-converter/StringConverterComponent.tsx
@@ -23,7 +23,7 @@ const convertToCamelCase = (input: string): string =>
 
 const convertToKebabCase = (input: string): string =>
   input
-    .replace(/\s+/g, "-")
+    .replace(/[\s_-]/g, "-")
     .replace(/([a-z])([A-Z])/g, "$1-$2")
     .toLowerCase();
 


### PR DESCRIPTION
During the String convertions for diffrent types, | kebab-case | SCREAM-KEBAB | are having misleading output, tried to add condition that reaplcaes the  '_', '-', ' ' with the '-' for the convertion type respectively, below are the error and output snippets.

"kebab-case"
![image](https://github.com/YourAverageTechBro/DevToolboxWeb/assets/59244101/f0d1fd9a-d525-492a-9da5-5da48a1c24bc)

Expected Output: snake-case-to-camel-case
![image](https://github.com/YourAverageTechBro/DevToolboxWeb/assets/59244101/1419ab11-e484-4b08-9432-67cd355b62d7)


"SCREAM-KEBAB"
![image](https://github.com/YourAverageTechBro/DevToolboxWeb/assets/59244101/a41106de-8f08-45dc-85fe-eb11b6d6152f)

Expected Output: SNAKE-CASE-TO-CAMEL-CASE
![image](https://github.com/YourAverageTechBro/DevToolboxWeb/assets/59244101/83d029b2-2e5f-4690-a5b7-1e99595cf5e4)
