### PR TITLE
[Suggestion] Adjust accessibility on tool list font colour

### DIFF
--- a/src/app/components/common/ToolList.tsx
+++ b/src/app/components/common/ToolList.tsx
@@ -124,12 +124,12 @@ export default function ToolList() {
         </div>
       </SignedOut>
       <Link
-        className={`w-full border-y py-3 px-4 hover:bg-gray-600`}
+        className={`w-full border-y py-3 px-4 bg-indigo-500 hover:bg-indigo-400`}
         href={`https://github.com/YourAverageTechBro/DevToolboxWeb`}
         target="_blank"
       >
-        <div className={"flex items-center gap-2 "}>
-          <StarIcon className={"w-6 h-6"} />
+        <div className={"flex items-center gap-2 text-white"}>
+          <StarIcon className={"w-6 h-6 text-white"} />
           Star Us On Github
         </div>
       </Link>
@@ -141,7 +141,7 @@ export default function ToolList() {
         })
         .map((toolOption) => (
           <Link
-            className={`w-full border-b py-3 px-4 hover:bg-gray-600 ${
+            className={`w-full border-b py-3 px-4 text-white hover:bg-gray-600 ${
               pathname === toolOption.path && "bg-gray-500"
             }`}
             key={toolOption.name}


### PR DESCRIPTION
### Suggested change
- Improve the readability of text within the application.
- Make a distinction between the tooling and the GitHub repo redirect.

### Why
- The black font on a dark gray background is quite difficult to read and raises accessibility concerns.

### Comments
- This happens elsewhere in the app but for now this PR makes minor changes to the tool list on the main page.
- If this suggestion is helpful, I'll be happy to look into other sections of the app.

### Preview of changes
#### Before
![image](https://github.com/YourAverageTechBro/DevToolboxWeb/assets/80278654/a23feb95-f657-474b-beb9-d860d74b9de8)
#### After
![image](https://github.com/YourAverageTechBro/DevToolboxWeb/assets/80278654/856b2e8d-c2ad-44e7-8751-38d7df220641)
